### PR TITLE
Add support for prod.js overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ config.get("AWS:accessKey");   // undefined
 config.get("FACEBOOK_APP_ID"); // Outputs your FACEBOOK_APP_ID
 ```
 
-### Development
+### Local Development
 In development, you may want to environment variables in a file instead of your `.bash_profile`.
 
 If you want to use this approach, you can override any server or client variable by creating a `dev.js` file in your `config` directory.  You'll want to add this file to your `.gitignore`.
 
-__NOTE:__ _The variables in this file will be exposed both on the client and the server, but this shouldn't be a problem since you should only be using this in development._
+For testing production locally, you may also specify a `prod.js` in the config directory. It will be imported when NODE_ENV is set to 'production'.
+
+__NOTE:__ _The variables in these files will be exposed both on the client and the server, but this shouldn't be a problem since you should only be using this locally._
 
 ## Methods
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,13 @@ class Config {
 
     this._server = this.getServerVars();
     this._client = this.getClientVars();
-    this._dev = this.getDevVars();
+    this._localOverrides = this.getLocalOverrides();
 
-    this._store = Object.assign({}, this._client, this._server, this._dev);
+    this._store = Object.assign({},
+      this._client,
+      this._server,
+      this._localOverrides
+    );
   }
 
   set(key, value) {
@@ -88,24 +92,21 @@ class Config {
     return clientVars;
   }
 
-  getDevVars() {
-    let devVars;
-
-    if (process.env.NODE_ENV === 'production') {
-      return {};
-    }
+  getLocalOverrides() {
+    let overrides;
+    const filename = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
 
     try {
-      devVars = require('../../../config/dev');
+      overrides = process.env.NODE_ENV === 'production'
+        ? require('../../../config/prod')
+        : require('../../../config/dev');
 
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(`Found a dev config in \`./config\`.`);
-      }
+      console.warn(`Using local overrides in \`./config/${filename}.js\`.`);
     } catch(e) {
-      devVars = {};
+      overrides = {};
     }
 
-    return devVars;
+    return overrides;
   }
 
   // Builds out a nested key to get nested values

--- a/test/server.js
+++ b/test/server.js
@@ -74,6 +74,11 @@ describe('Server', function() {
       );
     });
 
+    // Prod values
+     it('should not get the dev value', function() {
+      assert.isUndefined(config.get('PROD'));
+    });
+
     // Undefined values
     it('should return `undefined` for variables that are not defined', function() {
       assert.isUndefined(config.get('FOO'));

--- a/test/stubs/config/prod.js
+++ b/test/stubs/config/prod.js
@@ -1,0 +1,3 @@
+module.exports = {
+  PROD: true
+};


### PR DESCRIPTION
Allowed for a `prod.js` to be specified in the config directory, to enable local testing of a production environment.