### PR TITLE
Add support for test env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ In development, you may want to environment variables in a file instead of your 
 
 If you want to use this approach, you can override any server or client variable by creating a `dev.js` file in your `config` directory.  You'll want to add this file to your `.gitignore`.
 
-For testing production locally, you may also specify a `prod.js` in the config directory. It will be imported when NODE_ENV is set to 'production'.
+For running production locally, you may also specify a `prod.js` in the config directory. It will be imported when `process.env.NODE_ENV` is set to `production`.
+
+For testing, you can create a `test.js` in the config directory. Similarly, it will be loaded when `process.env.NODE_ENV` is set to `test`.
 
 __NOTE:__ _The variables in these files will be exposed both on the client and the server, but this shouldn't be a problem since you should only be using this locally._
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,14 +94,29 @@ class Config {
 
   getLocalOverrides() {
     let overrides;
-    const filename = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
+    const warnTemplate = 'Using local overrides in `./config/%s.js`.';
 
     try {
-      overrides = process.env.NODE_ENV === 'production'
-        ? require('../../../config/prod')
-        : require('../../../config/dev');
+      switch (process.env.NODE_ENV) {
+        case 'production':
+          overrides = require('../../../config/prod');
+          console.warn(warnTemplate, 'prod');
+          break;
 
-      console.warn(`Using local overrides in \`./config/${filename}.js\`.`);
+        case 'development':
+          overrides = require('../../../config/dev');
+          console.warn(warnTemplate, 'dev');
+          break;
+
+        case 'test':
+          overrides = require('../../../config/test');
+          console.warn(warnTemplate, 'test');
+          break;
+
+        default:
+          overrides = require('../../../config/dev');
+          console.warn('Could not match the provided NODE_ENV. Defaulting to `dev`');
+      }
     } catch(e) {
       overrides = {};
     }

--- a/test/server.js
+++ b/test/server.js
@@ -3,6 +3,9 @@ var mockery = require('mockery');
 var config;
 var CLIENT_VAR = require('./stubs/config/client');
 var SERVER_VAR = require('./stubs/config/server');
+var DEV_VAR = require('./stubs/config/dev');
+var PROD_VAR = require('./stubs/config/prod');
+var TEST_VAR = require('./stubs/config/test');
 
 describe('Server', function() {
   before(function() {
@@ -24,6 +27,14 @@ describe('Server', function() {
     mockery.registerSubstitute(
       '../../../config/dev',
       '../test/stubs/config/dev'
+    );
+    mockery.registerSubstitute(
+      '../../../config/prod',
+      '../test/stubs/config/prod'
+    );
+    mockery.registerSubstitute(
+      '../../../config/test',
+      '../test/stubs/config/test'
     );
 
     config = require('../lib/index');
@@ -70,13 +81,16 @@ describe('Server', function() {
      it('should get a dev value', function() {
       assert.strictEqual(
         config.get('DEV'),
-        true
+        DEV_VAR.DEV
       );
     });
 
-    // Prod values
+    // Other config values
      it('should not get the dev value', function() {
       assert.isUndefined(config.get('PROD'));
+    });
+    it('should not get the test value', function() {
+      assert.isUndefined(config.get('TEST'));
     });
 
     // Undefined values

--- a/test/stubs/config/test.js
+++ b/test/stubs/config/test.js
@@ -1,0 +1,3 @@
+module.exports = {
+  TEST: true
+};


### PR DESCRIPTION
Hi Naoufal 👋 

Hope everything's been going well with you!

At Unsplash, we're in the process of adding snapshot tests with Jest. An issue we've run into is that the snapshots change when you change the environment you're connected to (eg. switching from staging to prod in `dev.js` changes the `UNSPLASH_API_URL`).

Our solution is to add yet another environmental-dependent config, so that we can specify static values for the `test` environment, that won't change when we change our dev config.

My first thought was to add a catch-all, that would load a file named after the environment, but then I remembered that in Node, `require` statements can't be dynamic. As a result, I had to just add another condition to the `getLocalOverrides` method.

No worries if you feel like this addition is too 'niche' for this project. I opened a PR in case you found it useful, but if not we can just use our fork.